### PR TITLE
fix(issues list): Prevent race condition when adding a commnet or replying to an issue

### DIFF
--- a/web/src/components/new-comment-form/new-comment-form.tsx
+++ b/web/src/components/new-comment-form/new-comment-form.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react'
 import { TextAreaField } from "../text-field"
 import { Button } from "@/components/button"
 
-import type { ChangeEvent } from 'react'
+import type { ChangeEvent, FormEvent } from 'react'
 import type { NewCommentFormProps } from './types'
 
 const MAX_CHARACTERS_COUNT = 250
@@ -16,7 +16,9 @@ export default function NewCommentForm({ onSubmit }: NewCommentFormProps) {
     setContent(event.target.value)
   }
 
-  const handleSubmit = async () => {
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
     if (content.length > MAX_CHARACTERS_COUNT) return
     await onSubmit(content)
   }

--- a/web/src/components/new-reply-form/new-reply-form.tsx
+++ b/web/src/components/new-reply-form/new-reply-form.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react'
 import { TextAreaField } from "../text-field"
 import { Button } from "@/components/button"
 
-import type { ChangeEvent } from 'react'
+import type { ChangeEvent, FormEvent } from 'react'
 import type { NewReplyFormProps } from './types'
 
 const MAX_CHARACTERS_COUNT = 250
@@ -16,7 +16,9 @@ export default function NewReplyForm({ onSubmit }: NewReplyFormProps) {
     setContent(event.target.value)
   }
 
-  const handleSubmit = async () => {
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
     if (content.length > MAX_CHARACTERS_COUNT) return
     await onSubmit(content)
   }

--- a/web/src/components/upvote-button/upvote-button.tsx
+++ b/web/src/components/upvote-button/upvote-button.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, type MouseEvent } from 'react'
 import { ChevronIconUp } from "@/icons"
 
 import type { UpvoteButtonProps } from './types'
@@ -9,7 +9,10 @@ export default function UpvoteButton({ issueUuid, upvotes, initialActive = false
   const [upvotesCount, setUpvotesCount] = useState<number>(upvotes)
   const [selected, setSelected] = useState<boolean>(initialActive)
 
-  const handleClick = () => {
+  const handleClick = (event: MouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
+    event.preventDefault();
+
     const newSelected = !selected
     setSelected(newSelected)
 
@@ -37,6 +40,7 @@ export default function UpvoteButton({ issueUuid, upvotes, initialActive = false
         ${selected ? 'bg-savoy-blue text-white hover:opacity-80' : 'text-marian-blue bg-ghost-white hover:bg-periwinkle'}
       `}
       onClick={handleClick}
+      type="button"
     >
       <div className={`w-3 ${selected ? 'text-white' : 'text-savoy-blue'}`}>
         <ChevronIconUp />


### PR DESCRIPTION
There was something happening sometimes when a new issue or comment was created.. the result wasn't being reflected directly on the screen. This seems to be happening because the browser was reloading automatically when the comment or issue was created, which is the default behavior when a form is submitted. Adding `event.preventDefault()` to the event handler kills this behavior.